### PR TITLE
Add burning poem sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,8 @@
         <h1 id="home-heading"></h1>
         <button id="start">Start Reading</button>
       </div>
-      <div id="poem" class="hidden">
-        <p>[An Anklet's Chime]</p>
-        <p>(first poem placeholder)</p>
+      <div id="poem" class="poem hidden">
+        <p id="poem-text"></p>
       </div>
     </div>
     <div class="butterfly butterfly1"></div>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 const startButton = document.getElementById("start");
 const intro = document.getElementById("intro");
 const poem = document.getElementById("poem");
+const poemText = document.getElementById("poem-text");
 const content = document.getElementById("content");
 const lockScreen = document.getElementById("lock-screen");
 const passwordInput = document.getElementById("password");
@@ -108,6 +109,38 @@ const combos = [
   },
 ];
 
+const poems = [
+  "[An Anklet's Chime] (first poem placeholder)",
+  "(second poem placeholder)",
+  "(third poem placeholder)",
+];
+
+const displayTime = 30000;
+const burnDuration = 5000;
+let poemIndex = 0;
+
+function showPoem() {
+  poem.style.setProperty("--burn-duration", `${burnDuration}ms`);
+  poemText.textContent = poems[poemIndex];
+  poem.classList.remove("burn");
+  poem.classList.remove("hidden");
+
+  setTimeout(() => {
+    poem.classList.add("burn");
+    poem.addEventListener(
+      "animationend",
+      () => {
+        poem.classList.add("hidden");
+        poemIndex++;
+        if (poemIndex < poems.length) {
+          setTimeout(showPoem, 500);
+        }
+      },
+      { once: true },
+    );
+  }, displayTime);
+}
+
 const currentCombo = combos[Math.floor(Math.random() * combos.length)];
 if (hintElement) {
   hintElement.textContent = `hint: ${currentCombo.hint}`;
@@ -168,6 +201,8 @@ passwordInput.addEventListener("keydown", (e) => {
 });
 
 startButton.addEventListener("click", () => {
+  startButton.disabled = true;
   intro.classList.add("hidden");
-  poem.classList.remove("hidden");
+  poemIndex = 0;
+  showPoem();
 });

--- a/styles.css
+++ b/styles.css
@@ -175,6 +175,41 @@ button:hover {
   color: #f8d7e4;
 }
 
+#poem {
+  --burn-duration: 5s;
+  background: #fdf5ce;
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.1) 0,
+    rgba(255, 255, 255, 0.1) 2px,
+    transparent 2px,
+    transparent 4px
+  );
+  padding: 2rem;
+  margin: 0 auto;
+  width: 80%;
+  max-width: 600px;
+  border-radius: 10px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+
+#poem.burn {
+  animation: burn var(--burn-duration) forwards;
+}
+
+@keyframes burn {
+  0% {
+    clip-path: inset(0% 0% 0% 0%);
+    opacity: 1;
+  }
+  100% {
+    clip-path: inset(50% 50% 50% 50%);
+    opacity: 0;
+  }
+}
+
 .butterfly {
   position: absolute;
   z-index: 3;


### PR DESCRIPTION
## Summary
- show poems one by one on parchment paper
- animate parchment burning away before loading the next poem
- disable navigation so reading is linear

## Testing
- `npx prettier --check .`

------
https://chatgpt.com/codex/tasks/task_e_6853059441e48322abf3eb253e6afb0b