### PR TITLE
Add final message display

### DIFF
--- a/main.js
+++ b/main.js
@@ -182,6 +182,13 @@ const poems = [
   `Gentle Goodbye\n\nYou said it gently,\nlike someone reaching the end\nof a story they loved but couldn’t finish.\n\nThat love, no matter how warm,\ncan’t live on distance alone.\n\nYou were tired,\nof holding hope like a secret\nof waiting for a closeness\nto arrive through a screen.\n\nI didn’t blame you.\nI heard it in your voice—\nthe weight of emotion stretched too thin\nacross a distance we couldn’t soften.\n\nMaybe you let go before I was ready to,\nbecause you knew what it would cost\nto keep holding on across a distance\nthat wouldn’t close.\n\nI just wish\nmy hand had been there\nwhen your heart let go.\nnot a voice,\nbut something you could hold.`,
 ];
 
+const finalMessage = "YOUR MESSAGE HERE";
+
+function showFinalMessage() {
+  poemTextEl.textContent = "";
+  typeText(finalMessage);
+}
+
 function typeText(text, callback) {
   clearInterval(typingInterval);
   let i = 0;
@@ -222,7 +229,10 @@ function showPoemList() {
 
 function startPoems(index) {
   currentPoemIndex = index;
-  if (index >= poems.length) return;
+  if (index >= poems.length) {
+    showFinalMessage();
+    return;
+  }
   poemTextEl.textContent = "";
   typeText(poems[index], () => {
     startCountdown(8, () => startPoems(index + 1));


### PR DESCRIPTION
## Summary
- display a custom message after the last poem

## Testing
- `npx prettier --check .` *(fails: index.html, styles.css need formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68533060123483229257842c5607c425