### PR TITLE
Fix skip button to advance poems

### DIFF
--- a/main.js
+++ b/main.js
@@ -254,6 +254,15 @@ function skipPoem() {
     const cb = nextCallback;
     nextCallback = null;
     cb();
+  } else {
+    poemTextEl.textContent = "";
+    if (currentPoemIndex === -1) {
+      startPoems(0);
+    } else if (currentPoemIndex >= poems.length - 1) {
+      showFinalMessage();
+    } else {
+      startPoems(currentPoemIndex + 1);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- update `skipPoem` so the button can move to the next poem even while text is typing

## Testing
- `npx prettier --check main.js`
- `npx prettier --check .` *(fails: index.html, styles.css)*

------
https://chatgpt.com/codex/tasks/task_e_68547d1a7db88322b87cca9fe04e93dd